### PR TITLE
Replace benchmarkRun.id condition to fix local data evaluation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,7 @@ const runBenchmark = async () => {
             );
           }
 
-          if (benchmarkRun.id) {
+          if (benchmarkRun) {
             await saveResult(benchmarkRun.id, result);
           }
 
@@ -270,7 +270,7 @@ const runBenchmark = async () => {
   multibar.stop();
 
   // Complete benchmark run successfully
-  if (benchmarkRun.id) {
+  if (benchmarkRun) {
     await completeBenchmarkRun(benchmarkRun.id);
   }
 


### PR DESCRIPTION
The `if (benchmarkRun.id)` condition will fail with `getting property .id of undefined` when using a local data directory instead of the database as benchmarkRun is never instantiated otherwise.

I am not completely sure whether this is the correct fix but this change does allow the evaluation to proceed.

Thanks